### PR TITLE
Fix URLs due to move to JuliaImages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<html lang="en">  
+<html lang="en">
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -15,10 +15,10 @@
 			<div class="col-xs-8 col-xs-offset-2">
 				<br><br>
 				<h1 class="text-center">TestImages.jl</h1>
-				<h4 class="text-center">A repository of standard test images for <a href="https://github.com/timholy/Images.jl">Images.jl</a></h4>
-				<a href="https://travis-ci.org/timholy/TestImages.jl"><img src="https://travis-ci.org/timholy/TestImages.jl.png" class="center-block"></a>
+				<h4 class="text-center">A repository of standard test images for <a href="https://github.com/JuliaImages/Images.jl">Images.jl</a></h4>
+				<a href="https://travis-ci.org/JuliaImages/TestImages.jl"><img src="https://travis-ci.org/JuliaImages/TestImages.jl.png" class="center-block"></a>
 				<hr>
-				
+
 				<h3>Installation</h3>
 				<hr>
 				<h5>On Linux and OSX, this should install automatically. If you find yourself missing most of the images described <a href="#Images">below</a>, please try <code>Pkg.build("TestImages")</code>, which should trigger another attempt to download the standard images. </h5>
@@ -33,7 +33,7 @@
 
 				<h3>Contributing</h3>
 				<hr>
-				<h5>Anyone can contribute images to this repository by submitting a pull request at the <a href="https://github.com/timholy/TestImages.jl">github repo</a>. Do check the images for copyright or license issues before submitting.</h5>
+				<h5>Anyone can contribute images to this repository by submitting a pull request at the <a href="https://github.com/JuliaImages/TestImages.jl">github repo</a>. Do check the images for copyright or license issues before submitting.</h5>
 
 				<h5>The following steps should be followed to add an image/imageset to the repository :</h5>
 
@@ -57,7 +57,7 @@
 						<code>git push fork gh-pages</code>
 					</li>
 					<li>
-						Now submit a pull request to the <code>gh-pages</code> branch. Once accepted, the image or imageset will be stored at <br> https://github.com/timholy/TestImages.jl/blob/gh-pages/images/&#60;filename&#62;.
+						Now submit a pull request to the <code>gh-pages</code> branch. Once accepted, the image or imageset will be stored at <br> https://github.com/JuliaImages/TestImages.jl/blob/gh-pages/images/&#60;filename&#62;.
 					</li>
 				</ul>
 				<h5>Now that the images are added to the repository, we need to modify the source files of the TestImages.jl package to make them available for download.</h5>
@@ -89,4 +89,4 @@
 			</div>
 		</div>
 	</body>
-</html> 
+</html>


### PR DESCRIPTION
This is against the `gh-pages` branch, which I didn't remember to update when I first did the move.