### PR TITLE
Use AxisArray to encode the slice spacing for mri-stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: julia
 os:
   - linux
 julia:
-  - 0.4
   - 0.5
   - nightly
 notifications:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.4
+julia 0.5
 FileIO
+AxisArrays
 ZipFile

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,38 @@
+environment:
+  matrix:
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+
+branches:
+  only:
+    - master
+    - /release-.*/
+
+notifications:
+  - provider: Email
+    on_build_success: false
+    on_build_failure: false
+    on_build_status_changed: false
+
+install:
+# if there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
+# Download most recent Julia Windows binary
+  - ps: (new-object net.webclient).DownloadFile(
+        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        "C:\projects\julia-binary.exe")
+# Run installer silently, output to C:\projects\julia
+  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+
+build_script:
+# Need to convert from shallow to complete for Pkg.clone to work
+  - IF EXIST .git\shallow (git fetch --unshallow)
+  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.clone(pwd(), \"TestImages\"); Pkg.build(\"TestImages\")"
+
+test_script:
+  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"TestImages\")"

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -1,5 +1,7 @@
+__precompile__()
+
 module TestImages
-using FileIO
+using FileIO, AxisArrays
 
 export testimage
 
@@ -72,6 +74,13 @@ function testimage(filename, ops...)
         end
         havefile || error("$filename not found in the directory or the online repository. Here are the contents of the images/ directory:\n$(join(fls, '\n'))")
     end
-    load(imagefile, ops...)
+    img = load(imagefile, ops...)
+    if startswith(basename(imagefile), "mri-stack")
+        # orientation is posterior-right-superior,
+        # see http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm
+        return AxisArray(img, (:P, :R, :S), (1, 1, 5))
+    end
+    img
 end
-end
+
+end # module

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,3 @@
 ImageMagick
+Colors
+FixedPointNumbers

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,10 @@
-using TestImages
-using Base.Test  
+using TestImages, FixedPointNumbers, Colors, AxisArrays
+using Base.Test
 
 img = testimage("cameraman")
+@test isa(img, Matrix{Gray{N0f8}})
+img = testimage("mri-stack")
+@test isa(img, AxisArray)
+@test map(step, axisvalues(img)) == (1,1,5)
+
+nothing


### PR DESCRIPTION
For `mri-stack`, the slice spacing is different from the in-plane spacing; it makes sense to encode this so that other suites (e.g., GLVisualize, ImageView, etc) might make use of this.