### PR TITLE
Version 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 images/
 deps/*.log
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 1.0
   - 1.3
   - nightly
 notifications:
@@ -11,4 +10,4 @@ notifications:
 
 after_success:
   # push coverage results to Codecov
-  - julia -e 'using Pkg; cd(joinpath(pathof(TestImages), "..", "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg, TestImages; cd(joinpath(pathof(TestImages), "..", "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ language: julia
 os:
   - linux
   - osx
-  - windows
 julia:
   - 1.0
-  - 1.3
+  - 1.1
   - nightly
 notifications:
   email: false
 
 after_success:
   # push coverage results to Codecov
-  - julia -e 'using Pkg, TestImages; cd(joinpath(pathof(TestImages), "..", "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+  - julia -e 'using Pkg; cd(joinpath(pathof(TestImages), "..", "..")); Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.1
+  - 1.3
   - nightly
 notifications:
   email: false

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,0 +1,104 @@
+["autumn_leaves.png"]
+git-tree-sha1 = "cb84c2e2544f3517847d90c13cc11ab911fdbc5c"
+
+["blobs.gif"]
+git-tree-sha1 = "7b3fcffdeee78127e312d0abb44039b0d163ace6"
+
+["cameraman.tif"]
+git-tree-sha1 = "810109202e79feee6011ca1a7ed8935be688e337"
+
+["earth_apollo17.jpg"]
+git-tree-sha1 = "c065555adfcb3cf9c20bcd22e25d5bf88de320df"
+
+["fabio_color_256.png"]
+git-tree-sha1 = "4aada3dffc1369c9dcdeff243ea465db215a554f"
+
+["fabio_color_512.png"]
+git-tree-sha1 = "88cc93db49599ec8f3e25efa87e26cbb08527f7d"
+
+["fabio_gray_256.png"]
+git-tree-sha1 = "a865772ddbdb69737e6c65775bfa385f2a3ae550"
+
+["fabio_gray_512.png"]
+git-tree-sha1 = "087a6f6a021bf83072e023b6de5f89784ef3d064"
+
+["hela-cells.tif"]
+git-tree-sha1 = "aa9fd486b2deeba5bdb81f69c0f462f2dde1dd20"
+
+["house.tif"]
+git-tree-sha1 = "fc2cafa10f1aa685df851b9f19b8c7b06ee39a6d"
+
+["jetplane.tif"]
+git-tree-sha1 = "db3f58645968c94ad801944efa760024cb5739dd"
+
+["lake_color.tif"]
+git-tree-sha1 = "20b127f4bcf12c53873c035c03e572f3bcc2717f"
+
+["lake_gray.tif"]
+git-tree-sha1 = "8b8ca50da02edb312129fb88fcf291f9507cdc4e"
+
+["lena_color_256.tif"]
+git-tree-sha1 = "1cd86ce19b321e5ac8264779bec2dd9d34b707ce"
+
+["lena_color_512.tif"]
+git-tree-sha1 = "90756db35493c3cef4887afb94bb0bb5723be8bd"
+
+["lena_gray_16bit.png"]
+git-tree-sha1 = "395cd7fe40505d9a079baf7b60f40c79c6bddc31"
+
+["lena_gray_256.tif"]
+git-tree-sha1 = "17c4d34059095b17f3f20ee71d2a48771b807e58"
+
+["lena_gray_512.tif"]
+git-tree-sha1 = "48911ab84c3d0f5a7a7bb215d0181fefbb109980"
+
+["lighthouse.png"]
+git-tree-sha1 = "8455066b3de6966cbf02f5ce3cbf5ecfbcf4765b"
+
+["livingroom.tif"]
+git-tree-sha1 = "a3bff98dfed27ec51751345f9d0a7dabab7fa0a3"
+
+["m51.tif"]
+git-tree-sha1 = "8b0386f5f87400db92113ebac58694d17ba25f7b"
+
+["mandril_color.tif"]
+git-tree-sha1 = "70ca089e5f05676a3e2046f63a2931ef164afc6f"
+
+["mandril_gray.tif"]
+git-tree-sha1 = "a42b60b1d88787d71af959409d558f4f03b4a46c"
+
+["mandrill.tiff"]
+git-tree-sha1 = "9504f96bdf12c0bbfd1f90dff2f9210f0c72e335"
+
+["moonsurface.tiff"]
+git-tree-sha1 = "a34653dfa27d994967ec4d9a17fd1618116bd900"
+
+["mountainstream.png"]
+git-tree-sha1 = "05b8764b06dc0607a6468550d144310a3800b5bc"
+
+["mri-stack.tif"]
+git-tree-sha1 = "ead8f7a5d70393124e8cdabada12140ac7b29499"
+
+["multi-channel-time-series.ome.tif"]
+git-tree-sha1 = "a486b6128b554afeff943b4a09e4a79631554b0f"
+
+["peppers_color.tif"]
+git-tree-sha1 = "aac2bcc734bf4ede606117cb7b33c7ee12f206d4"
+
+["peppers_gray.tif"]
+git-tree-sha1 = "323350f5c0811cb1cfb31770854b1df637088a37"
+
+["pirate.tif"]
+git-tree-sha1 = "0cd12429a74b8fcaf8eb04e94b445242f1f1c4b1"
+
+["toucan.png"]
+git-tree-sha1 = "923982b64daaba909da6dfc379ee2afe5e49e067"
+
+["walkbridge.tif"]
+git-tree-sha1 = "ac2dd42087a89cc33ae2cf078e5d84868287fbf0"
+
+["woman_blonde.tif"]
+git-tree-sha1 = "424a4bd71bf41ae2ed87d9dbeeb081a44623fe9e"
+
+["woman_darkhair.tif"]
+git-tree-sha1 = "43727086a784f02b67ce545a0c61b81edca41608"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestImages"
 uuid = "5e47fb64-e119-507b-a336-dd2b206d9990"
-version = "0.6"
+version = "0.5.1"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
@@ -8,10 +8,10 @@ FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
+julia = "1"
 AxisArrays = "0.3"
 FileIO = "1"
 ZipFile = "0.7, 0.8"
-julia = "1"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,18 @@
 name = "TestImages"
 uuid = "5e47fb64-e119-507b-a336-dd2b206d9990"
-version = "0.5.1"
+version = "0.6.0"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
-julia = "1"
 AxisArrays = "0.3"
 FileIO = "1"
 ZipFile = "0.7, 0.8"
+julia = "1"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestImages"
 uuid = "5e47fb64-e119-507b-a336-dd2b206d9990"
-version = "0.6.0"
+version = "1.0.0"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
@@ -12,7 +12,7 @@ ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 AxisArrays = "0.3"
 FileIO = "1"
 ZipFile = "0.7, 0.8"
-julia = "1"
+julia = "1.3"
 
 [extras]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"

--- a/README.md
+++ b/README.md
@@ -13,28 +13,19 @@ Full documentation and description of the images available in TestImages.jl can 
 
 ## Installation
 
-On Linux and OSX, this should install automatically. If you find yourself missing most of the images described in the documentation, please try `Pkg.build("TestImages")`, which should trigger another attempt to download the images.
-
-In case you would like to download other images from the repository not in the standard set, you can call the ```testimage``` with the image name and it will be downloaded from the repository.
-
-On Windows, the ```download``` command, used to download images from the archives, is not fully supported. You can manually download the files listed in ```deps\build.jl``` from the ```images``` folder of the ```gh-pages``` branch of this repository and place them in ```TestImages\images```.
+`TestImages` doesn't support image IO by itself, which means you need to install some backends on your choice, e.g., [ImageMagick.jl](https://github.com/JuliaIO/ImageMagick.jl), [QuartzImageIO](https://github.com/JuliaIO/QuartzImageIO.jl), [OMETIFF.jl](https://github.com/tlnagy/OMETIFF.jl).
 
 ## Usage
 
 ```
 using TestImages
 
-img = testimage("cameraman")
+img = testimage("cameraman.tif") # fullname
+img = testimage("cameraman) # without extension works
+img = testimage("cam") # with only partial name also works
 ```
 
-The standard test images are downloaded to an `images/` directory
-inside this package.  Any image file stored in this directory is
-accessible through the `testimage` function.  You can supply the file
-extension (e.g., ".png", ".tif", etc), but it is not required. Indeed,
-the matching is performed using just the portion of the filename you
-supply, so `testimage("cam")` yields the same result.
-
-In case the image is not present locally, the ```testimage``` function will check the online repository and download it for you.
+Images will be automatically downloaded into artifact folders (e.g., `images/` for julia `< v1.3`) when you load the image for the first time.
 
 ## Contributing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 environment:
   matrix:
-  - julia_version: 1.0
   - julia_version: 1.3
   - julia_version: nightly
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1.1
+  - julia_version: 1.3
   - julia_version: nightly
 
 platform:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
   - julia_version: 1.0
-  - julia_version: 1
+  - julia_version: 1.1
   - julia_version: nightly
 
 platform:

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,39 @@
+imagedir = joinpath(dirname(@__FILE__), "..", "images")
+if !isdir(imagedir)
+    mkdir(imagedir)
+end
+
+REPO_URL = "https://github.com/timholy/TestImages.jl/blob/gh-pages/images/"
+
+stdfiles = [
+    "cameraman.tif" ,
+    "house.tif" ,
+    "jetplane.tif" ,
+    "lake_gray.tif" ,
+    "lake_color.tif" ,
+    "lena_color_256.tif" ,
+    "lena_color_512.tif" ,
+    "lena_gray_256.tif" ,
+    "lena_gray_512.tif" ,
+    "livingroom.tif" ,
+    "mandril_color.tif" ,
+    "mandril_gray.tif" ,
+    "mandrill.tiff" ,
+    "peppers_color.tif" ,
+    "peppers_gray.tif" ,
+    "pirate.tif" ,
+    "walkbridge.tif" ,
+    "woman_blonde.tif" ,
+    "woman_darkhair.tif" ,
+]
+
+@info "Downloading standard test images"
+for f in stdfiles
+    fn = joinpath(imagedir, f)
+    if !isfile(fn)
+        @info "Downloading $fn"
+        download(REPO_URL*f*"?raw=true", joinpath(imagedir, f))
+    end
+end
+
+@info "Download Completed."

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,26 +1,4 @@
 using TestImages
 
-stdfiles = [
-    "cameraman.tif" ,
-    "house.tif" ,
-    "jetplane.tif" ,
-    "lake_gray.tif" ,
-    "lake_color.tif" ,
-    "lena_color_256.tif" ,
-    "lena_color_512.tif" ,
-    "lena_gray_256.tif" ,
-    "lena_gray_512.tif" ,
-    "livingroom.tif" ,
-    "mandril_color.tif" ,
-    "mandril_gray.tif" ,
-    "mandrill.tiff" ,
-    "peppers_color.tif" ,
-    "peppers_gray.tif" ,
-    "pirate.tif" ,
-    "walkbridge.tif" ,
-    "woman_blonde.tif" ,
-    "woman_darkhair.tif" ,
-]
-
 @info "Downloading standard test images"
-foreach(x->testimage(x; download_only=true), stdfiles)
+foreach(x->testimage(x; download_only=true), TestImages.remotefiles)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,9 +1,4 @@
-imagedir = joinpath(dirname(@__FILE__), "..", "images")
-if !isdir(imagedir)
-    mkdir(imagedir)
-end
-
-REPO_URL = "https://github.com/timholy/TestImages.jl/blob/gh-pages/images/"
+using TestImages
 
 stdfiles = [
     "cameraman.tif" ,
@@ -28,12 +23,4 @@ stdfiles = [
 ]
 
 @info "Downloading standard test images"
-for f in stdfiles
-    fn = joinpath(imagedir, f)
-    if !isfile(fn)
-        @info "Downloading $fn"
-        download(REPO_URL*f*"?raw=true", joinpath(imagedir, f))
-    end
-end
-
-@info "Download Completed."
+foreach(x->testimage(x; download_only=true), stdfiles)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,3 @@ img = testimage("mri-stack")
 @test map(step, axisvalues(img)) == (1,1,5)
 @test_nowarn testimage("c")
 @test_throws ArgumentError testimage("nonexistence.png")
-
-@test all([f in TestImages.remotefiles for f in readdir(TestImages.imagedir)])


### PR DESCRIPTION
@johnnychen94, I messed this up with #56; consequently, I took #54 (which I had forgotten about) and rebased.

See what you think of this. This version commits to the Artifacts system and thus becomes Julia 1.3+ only. Older Julia versions are supported by previous releases. It also seems to fix https://github.com/JuliaImages/TestImages.jl/pull/54#discussion_r351073517. Also calling it v1.0.0, if that seems appropriate.