### PR TITLE
test each files in remotefiles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,8 +18,8 @@ julia = "1.3"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
+OMETIFF = "2d0ec36b-e807-5756-994b-45af29551fcf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Colors", "FixedPointNumbers", "ImageMagick", "QuartzImageIO", "Test"]
+test = ["Colors", "FixedPointNumbers", "ImageMagick", "OMETIFF", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
 using TestImages, FixedPointNumbers, Colors, AxisArrays
 using Test
 
+# make sure all files in remotefiles are valid image files
+foreach(TestImages.remotefiles) do img_name
+    img = testimage(img_name)
+    @test isa(img, AbstractArray{<:Colorant})
+end
+
 img = testimage("cameraman")
 @test isa(img, Matrix{Gray{N0f8}})
 img = testimage("mri-stack")


### PR DESCRIPTION
@timholy Although I'm pretty sure the problem in https://github.com/JuliaImages/juliaimages.github.io/pull/98 isn't caused by the specific "mandrill" image, it can still be reasonable just to make sure all images are valid.