### PR TITLE
interpolate remotefiles into docstring of testimage

### DIFF
--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -63,8 +63,12 @@ julia> img = testimage("cameraman"); # without extension works
 julia> img = testimage("c"); # with only partial name also works
 ```
 
-`TestImages.remotefiles` stores the full list of available images. You can also check
+# Extended help
+
+The following is a complete list of testimages, you can also check them at
 https://testimages.juliaimages.org/
+
+$(reduce((x, y)->join([x, "\n - \`\"", splitext(y)[1], "\"\`"]), sort(remotefiles); init=""))
 """
 function testimage(filename; download_only = false, ops...)
     imagefile = image_path(full_imagename(filename))


### PR DESCRIPTION
I feel inconvenient to do 

```julia
foreach(println, TestImages.remotefiles)
```

when I forget the image names, so I decide to just add them into the docstring of `testimage`

Here's the preview result:

```markdown
# Extended help

The following is a complete list of testimages, you can also check them at https://testimages.juliaimages.org/

  * `"autumn_leaves"`
  * `"blobs"`
  * `"cameraman"`
  * `"earth_apollo17"`
  * `"fabio_color_256"`
  * `"fabio_color_512"`
  * `"fabio_gray_256"`
```