### PR TITLE
remove ZipFile dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,17 +1,15 @@
 name = "TestImages"
 uuid = "5e47fb64-e119-507b-a336-dd2b206d9990"
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 AxisArrays = "0.3, 0.4"
 FileIO = "1"
-ZipFile = "0.7, 0.8, 0.9"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
This is introduced six years ago https://github.com/JuliaImages/TestImages.jl/commit/491bd05599d010fd1a428bc42f0a4d077007c77d and I'm not sure it's still needed now. The test says it's okay to remove it.