### PR TITLE
give better hints and fallback when filename mismatches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,10 +6,12 @@ version = "1.0.3"
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
 
 [compat]
 AxisArrays = "0.3, 0.4"
 FileIO = "1"
+StringDistances = "0.6"
 julia = "1.3"
 
 [extras]
@@ -17,7 +19,9 @@ Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 OMETIFF = "2d0ec36b-e807-5756-994b-45af29551fcf"
+ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
+Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Colors", "FixedPointNumbers", "ImageMagick", "OMETIFF", "Test"]
+test = ["Colors", "FixedPointNumbers", "ImageMagick", "OMETIFF", "ReferenceTests", "Suppressor", "Test"]

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -130,7 +130,7 @@ function image_path(imagename)
     return joinpath(artifact_path(file_hash), imagename)
 end
 
-_findall(name; min_score=0.6) = findall(name, remotefiles, Jaro(), min_score=min_score)
-_findmax(name; min_score=0.9) = findmax(name, remotefiles, Jaro(), min_score=min_score)
+_findall(name; min_score=0.6) = findall(name, remotefiles, Winkler(Jaro()), min_score=min_score)
+_findmax(name; min_score=0.8) = findmax(name, remotefiles, Winkler(Jaro()), min_score=min_score)
 
 end # module

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -101,7 +101,7 @@ function full_imagename(filename)
         if isnothing(best_match[2])
             similar_matches = remotefiles[_findall(filename)]
             if !isempty(similar_matches)
-                similar_matches_msg = "  * " * join(similar_matches, "\n  * ")
+                similar_matches_msg = "  * \"" * join(similar_matches, "\"\n  * \"") * "\""
                 warn_msg = "$(warn_msg) Do you mean one of the following?\n$(similar_matches_msg)"
             end
             throw(ArgumentError(warn_msg))
@@ -130,7 +130,7 @@ function image_path(imagename)
     return joinpath(artifact_path(file_hash), imagename)
 end
 
-_findall(name; min_score=0.5) = findall(name, remotefiles, TokenMax(Levenshtein()), min_score=min_score)
-_findmax(name; min_score=0.8) = findmax(name, remotefiles, TokenMax(Levenshtein()), min_score=min_score)
+_findall(name; min_score=0.6) = findall(name, remotefiles, Jaro(), min_score=min_score)
+_findmax(name; min_score=0.9) = findmax(name, remotefiles, Jaro(), min_score=min_score)
 
 end # module

--- a/test/references/abcd_err.txt
+++ b/test/references/abcd_err.txt
@@ -1,0 +1,4 @@
+ArgumentError: "abcd.png" not found in `TestImages.remotefiles`. Do you mean one of the following?
+  * autumn_leaves.png
+  * lena_gray_16bit.png
+  * toucan.png

--- a/test/references/abcd_err.txt
+++ b/test/references/abcd_err.txt
@@ -1,0 +1,2 @@
+ArgumentError: "abcd.png" not found in `TestImages.remotefiles`. Do you mean one of the following?
+  * "toucan.png"

--- a/test/references/abcd_err.txt
+++ b/test/references/abcd_err.txt
@@ -1,4 +1,0 @@
-ArgumentError: "abcd.png" not found in `TestImages.remotefiles`. Do you mean one of the following?
-  * autumn_leaves.png
-  * lena_gray_16bit.png
-  * toucan.png

--- a/test/references/camereman_warning.txt
+++ b/test/references/camereman_warning.txt
@@ -1,0 +1,1 @@
+┌ Warning: "camereman" not found in `TestImages.remotefiles`. Load "cameraman.tif" instead.

--- a/test/references/leans_err.txt
+++ b/test/references/leans_err.txt
@@ -1,2 +1,0 @@
-ArgumentError: "leans" not found in `TestImages.remotefiles`. Do you mean one of the following?
-  * autumn_leaves.png

--- a/test/references/leans_err.txt
+++ b/test/references/leans_err.txt
@@ -1,0 +1,2 @@
+ArgumentError: "leans" not found in `TestImages.remotefiles`. Do you mean one of the following?
+  * autumn_leaves.png

--- a/test/references/leans_err.txt
+++ b/test/references/leans_err.txt
@@ -1,0 +1,4 @@
+ArgumentError: "leans" not found in `TestImages.remotefiles`. Do you mean one of the following?
+  * "hela-cells.tif"
+  * "jetplane.tif"
+  * "multi-channel-time-series.ome.tif"

--- a/test/references/leaves_warning.txt
+++ b/test/references/leaves_warning.txt
@@ -1,0 +1,1 @@
+┌ Warning: "leaves.png" not found in `TestImages.remotefiles`. Load "autumn_leaves.png" instead.

--- a/test/references/leaves_warning.txt
+++ b/test/references/leaves_warning.txt
@@ -1,1 +1,0 @@
-┌ Warning: "leaves.png" not found in `TestImages.remotefiles`. Load "autumn_leaves.png" instead.

--- a/test/references/nonexistence_err.txt
+++ b/test/references/nonexistence_err.txt
@@ -1,0 +1,4 @@
+ArgumentError: "nonexistence.png" not found in `TestImages.remotefiles`. Do you mean one of the following?
+  * "lighthouse.png"
+  * "mountainstream.png"
+  * "toucan.png"

--- a/test/references/nonexistence_err.txt
+++ b/test/references/nonexistence_err.txt
@@ -1,2 +1,0 @@
-ArgumentError: "nonexistence.png" not found in `TestImages.remotefiles`. Do you mean one of the following?
-  * mountainstream.png

--- a/test/references/nonexistence_err.txt
+++ b/test/references/nonexistence_err.txt
@@ -1,0 +1,2 @@
+ArgumentError: "nonexistence.png" not found in `TestImages.remotefiles`. Do you mean one of the following?
+  * mountainstream.png

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TestImages, FixedPointNumbers, Colors, AxisArrays
-using Test
+using Test, ReferenceTests, Suppressor
 
 # make sure all files in remotefiles are valid image files
 foreach(TestImages.remotefiles) do img_name
@@ -7,10 +7,24 @@ foreach(TestImages.remotefiles) do img_name
     @test isa(img, AbstractArray{<:Colorant})
 end
 
+include("utils.jl")
+
 img = testimage("cameraman")
 @test isa(img, Matrix{Gray{N0f8}})
 img = testimage("mri-stack")
 @test isa(img, AxisArray)
 @test map(step, axisvalues(img)) == (1,1,5)
 @test_nowarn testimage("c")
-@test_throws ArgumentError testimage("nonexistence.png")
+
+# mismatch handling
+err_str = @except_str testimage("nonexistence.png") ArgumentError
+@test_reference "references/nonexistence_err.txt" err_str
+
+err_str = @except_str testimage("leans") ArgumentError
+@test_reference "references/leans_err.txt" err_str
+
+err_str = @except_str testimage("abcd.png") ArgumentError
+@test_reference "references/abcd_err.txt" err_str
+
+err_str = @capture_err testimage("leaves.png")
+@test_reference "references/leaves_warning.txt" split(err_str, "\n")[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ img = testimage("mri-stack")
 @test_nowarn testimage("c")
 
 # mismatch handling
+# Note: the behavior might change as `remotefiles` changes
 err_str = @except_str testimage("nonexistence.png") ArgumentError
 @test_reference "references/nonexistence_err.txt" err_str
 
@@ -26,5 +27,5 @@ err_str = @except_str testimage("leans") ArgumentError
 err_str = @except_str testimage("abcd.png") ArgumentError
 @test_reference "references/abcd_err.txt" err_str
 
-err_str = @capture_err testimage("leaves.png")
-@test_reference "references/leaves_warning.txt" split(err_str, "\n")[1]
+err_str = @capture_err testimage("camereman")
+@test_reference "references/camereman_warning.txt" split(err_str, "\n")[1]

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,15 @@
+macro except_str(expr, err_type)
+    return quote
+        let err = nothing
+            try
+                $(esc(expr))
+            catch err
+            end
+            err === nothing && error("expected failure, but no exception thrown")
+            @test typeof(err) === $(esc(err_type))
+            buf = IOBuffer()
+            showerror(buf, err)
+            String(take!(buf))
+        end
+    end
+end


### PR DESCRIPTION
The error handling behavior is changed/improved:

* output all candidates with score > 0.5
* if there are candidates with score > 0.8, load the one with the largest score

I'm not string experts, the distance `TokenMax(Levenshtein())` is somehow randomly chosen. In [StringDistances](https://github.com/matthieugomez/StringDistances.jl) it says [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy) uses this distance.

```julia
julia> testimage("abcde")
ERROR: ArgumentError: "abcde" not found in `TestImages.remotefiles`.
Stacktrace:
 [1] full_imagename(::String) at /Users/jc/Documents/Julia/TestImages.jl/src/TestImages.jl:107
 [2] testimage(::String; download_only::Bool, ops::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/jc/Documents/Julia/TestImages.jl/src/TestImages.jl:75
 [3] testimage(::String) at /Users/jc/Documents/Julia/TestImages.jl/src/TestImages.jl:75
 [4] top-level scope at REPL[2]:1

julia> testimage("lean")
ERROR: ArgumentError: "lean" not found in `TestImages.remotefiles`. Do you mean one of the following?
  * autumn_leaves.png
Stacktrace:
 [1] full_imagename(::String) at /Users/jc/Documents/Julia/TestImages.jl/src/TestImages.jl:107
 [2] testimage(::String; download_only::Bool, ops::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /Users/jc/Documents/Julia/TestImages.jl/src/TestImages.jl:75
 [3] testimage(::String) at /Users/jc/Documents/Julia/TestImages.jl/src/TestImages.jl:75
 [4] top-level scope at REPL[3]:1

julia> testimage("leaves")
┌ Warning: "leaves" not found in `TestImages.remotefiles`. Load "autumn_leaves.png" instead.
└ @ TestImages ~/Documents/Julia/TestImages.jl/src/TestImages.jl:110
...

julia> testimage("color")
┌ Warning: "color" not found in `TestImages.remotefiles`. Load "fabio_color_256.png" instead.
└ @ TestImages ~/Documents/Julia/TestImages.jl/src/TestImages.jl:110
...

julia> testimage("lean_color")
ERROR: ArgumentError: "lean_color" not found in `TestImages.remotefiles`. Do you mean one of the following?
  * fabio_color_256.png
  * fabio_color_512.png
  * lake_color.tif
  * lena_color_256.tif
  * lena_color_512.tif
  * mandril_color.tif
  * peppers_color.tif
```