### PR TITLE
update the instruction of how to add new images

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
 
 				<ul>
 					<li>
-						Do <code>git checkout -b gh-pages</code> in your local repository folder. <code>Pkg.dir("TestImages")</code> gives the location of the repo.
+						Do <code>git checkout gh-pages</code> in your local repository folder. <code>Pkg.dir("TestImages")</code> gives the location of the repo.
 					</li>
 					<li>
 						Add the image locally to the <code>images/</code> folder on your machine.
@@ -75,19 +75,22 @@
 						<code>git commit -m "Adds &#60;filename&#62; to the repository from link &#60;link&#62;"</code>
 					</li>
 					<li>
-						<code>git push fork gh-pages</code>
+						<code>git push &#60;fork&#62; gh-pages</code>
 					</li>
 					<li>
-						Now submit a pull request to the <code>gh-pages</code> branch. Once accepted, the image or imageset will be stored at <br> https://github.com/JuliaImages/TestImages.jl/blob/gh-pages/images/&#60;filename&#62;.
+						Now submit a pull request to the <code>gh-pages</code> branch. Once accepted, the image or imageset will be stored at <code> https://github.com/JuliaImages/TestImages.jl/blob/gh-pages/images/&#60;filename&#62;</code>.
 					</li>
 				</ul>
-				<p>Now that the images are added to the repository, we need to modify the source files of the TestImages.jl package to make them available for download.</p>
+				<p>Now that the images are added to the repository, maintainers will then create a tag <code>v*-artifacts</code> and release an tarball artifact for this commit. After that we need to modify the source files of the TestImages.jl package to make them available for download.</p>
 				<ul>
 					<li>
 						Do <code>git checkout master</code> to return to the master branch.
 					</li>
 					<li>
-						Modify <code>src/TestImages.jl</code> : Add an entry with the filename to the <code>remotedict</code> dictionary.
+						Modify <code>src/TestImages.jl</code> : Add an entry with the filename to the <code>remotefiles</code> dictionary.
+					</li>
+					<li>
+						Modify <code>Artifacts.toml</code>: updates <code>[images]</code> section with the newly released artifacts.
 					</li>
 					<li>
 						Do <code>git add --all</code> to add the changed source files.
@@ -96,7 +99,7 @@
 						<code>git commit -m "Adds &#60;filename&#62; to package"</code>
 					</li>
 					<li>
-						<code>git push fork master</code>
+						<code>git push &#60;fork&#62; master</code>
 					</li>
 					<li>
 						Now submit a pull request to the <code>master</code> branch. Once accepted, the image or imageset will be available for download to users of TestImages.jl.


### PR DESCRIPTION
With #73 and #75, all images are now archived in one tarball and provided by PkgServer. The workflow has changed a bit:

1. [contributor] add new images to `images`
2. +[maintainer] when there are new images added, maintainers need to create a `v*-artifacts` tag in `gh-pages` branch
3. +[CI] the artifacts CI will then create a release for this tag, build and upload artifacts to the release
4. [contributor] update `remotefiles` in `src/TestImages.jl` in `master` branch
5. +[contributor] update `Artifacts.toml` in `master` branch; an example `Artifacts.toml` can be found in the release notes, for example in [v1.2.0-artifacts](https://github.com/JuliaImages/TestImages.jl/releases/tag/v1.2.0-artifacts).
6. [maintainer] call `@JuliaRegistrator register` to tag a new release for this

Currently, we still need to update `remotefiles`. In the future, we can mimic this with a function that lists every file in the artifacts dir.

@timholy please merge this when you get how the new things working