### PR TITLE
unexport shepp_logan and add depwarn to highContrast

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
 
 [compat]
-ColorTypes = "0.8, 0.9, 0.10"
 AxisArrays = "0.3, 0.4"
+ColorTypes = "0.8, 0.9, 0.10"
 FileIO = "1"
 StringDistances = "0.6, 0.7, 0.8"
 julia = "1.3"

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -5,7 +5,11 @@ using StringDistances
 using ColorTypes
 const artifacts_toml = abspath(joinpath(@__DIR__, "..", "Artifacts.toml"))
 
-export testimage, shepp_logan
+export testimage
+
+# TODO: export shepp_logan when we remove Images.shepp_logan
+# https://github.com/JuliaImages/Images.jl/pull/904
+# export shepp_logan
 
 remotefiles = [
     "autumn_leaves.png" ,
@@ -137,10 +141,17 @@ MRI version [2] is calculated.
 # References
 
 [1] Shepp, Lawrence A., and Benjamin F. Logan. "The Fourier reconstruction of a head section." _IEEE Transactions on nuclear science_ 21.3 (1974): 21-43.
+
 [2] Toft, Peter Aundal. "The Radon transform-theory and implementation." (1996): 201.
+
 [3] Jain, Anil K. Fundamentals of digital image processing. _Prentice-Hall, Inc._, (1989): 439.
 """
-function shepp_logan(N::Integer, M::Integer; high_contrast=true)
+function shepp_logan(N::Integer, M::Integer; high_contrast=true, highContrast=nothing)
+    if !isnothing(highContrast)
+        # compatbitity to Images.shepp_logan
+        # remove this when we remove Images.shepp_logan
+        Base.depwarn("keyword `highContrast` is deprecated, use `high_contrast` instead.", :shepp_logan)
+    end
     x = Array(range(-1, stop=1, length=M)')
     y = Array(range(1, stop=-1, length=N))
   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using TestImages, FixedPointNumbers, Colors, AxisArrays
 using Test, ReferenceTests, Suppressor
 using ImageContrastAdjustment
 
+using TestImages: shepp_logan # will be exported in future release
+
 # make sure all files in remotefiles are valid image files
 foreach(TestImages.remotefiles) do img_name
     img = testimage(img_name)


### PR DESCRIPTION
I didn't foresee the name conflict when I port `shepp_logan` in #77 and I have to unexport this symbol right now to appropriately deprecate `Images.shepp_logan`.

The first step of Option 1 in https://github.com/JuliaImages/Images.jl/pull/904#issuecomment-662270008

Given that #77 is released yesterday and I bet nobody is actually using it, I don't plan to tag a breaking release for this.