### PR TITLE
Add a few precompile statements

### DIFF
--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -146,7 +146,7 @@ MRI version [2] is calculated.
 
 [3] Jain, Anil K. Fundamentals of digital image processing. _Prentice-Hall, Inc._, (1989): 439.
 """
-function shepp_logan(N::Integer, M::Integer; high_contrast=true, highContrast=nothing)
+function shepp_logan(N::Int, M::Int; high_contrast::Bool=true, highContrast=nothing)
     if !isnothing(highContrast)
         # compatbitity to Images.shepp_logan
         # remove this when we remove Images.shepp_logan
@@ -154,7 +154,7 @@ function shepp_logan(N::Integer, M::Integer; high_contrast=true, highContrast=no
     end
     x = Array(range(-1, stop=1, length=M)')
     y = Array(range(1, stop=-1, length=N))
-  
+
     # follow the notation in [2]
     A = high_contrast ?
           # high contrast (MRI) version of the phantom -- [2] p.201
@@ -179,7 +179,7 @@ function shepp_logan(N::Integer, M::Integer; high_contrast=true, highContrast=no
         # a faster case when ϕ == 0.0
         abs2(dx * b) + abs2(dy * a) < (a * b)^2
     end
-  
+
     P = zeros(Gray{Float64}, N, M)
     for l = 1:length(ϕ)
         if ϕ[l] == 0.0
@@ -189,9 +189,11 @@ function shepp_logan(N::Integer, M::Integer; high_contrast=true, highContrast=no
             @. P = gray(P) + A[l] * _ellipse(x - x₀[l], y - y₀[l], a[l], b[l], sin_ϕ, cos_ϕ)
         end
     end
-  
+
     return P
 end
-shepp_logan(N::Integer; kwargs...) = shepp_logan(N, N; kwargs...)
+shepp_logan(N::Integer, M::Integer; kwargs...) = shepp_logan(Int(N), Int(M); kwargs...)
+shepp_logan(N::Integer; kwargs...) = shepp_logan(Int(N), Int(N); kwargs...)
+
 
 end # module

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -74,7 +74,7 @@ https://testimages.juliaimages.org/
 
 $(reduce((x, y)->join([x, "\n - \`\"", splitext(y)[1], "\"\`"]), sort(remotefiles); init=""))
 """
-function testimage(filename; download_only = false, ops...)
+function testimage(filename; download_only::Bool = false, ops...)
     imagefile = image_path(full_imagename(filename))
 
     download_only && return imagefile
@@ -195,5 +195,12 @@ end
 shepp_logan(N::Integer, M::Integer; kwargs...) = shepp_logan(Int(N), Int(M); kwargs...)
 shepp_logan(N::Integer; kwargs...) = shepp_logan(Int(N), Int(N); kwargs...)
 
+function _precompile_()
+    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
+    @assert precompile(image_path, (String,))
+    @assert precompile(testimage, (String,))
+    @assert precompile(shepp_logan, (Int,Int))
+end
+VERSION >= v"1.4.2" && _precompile_() # https://github.com/JuliaLang/julia/pull/35378
 
 end # module


### PR DESCRIPTION
The changes to the `shepp_logan` implementation follow [this recommendation](https://docs.julialang.org/en/v1/manual/style-guide/#Handle-excess-argument-diversity-in-the-caller). The idea is to standardize the inputs in "small functions" that compile quickly and then compile the big function just once. Obviously this isn't workable for many functions which intrinsically need to handle different types, but in cases like these it makes sense.

Shaves off about 0.25s from the first invocation of `testimage`.