### PR TITLE
WIP: offset the axes of the PSF

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "1.3.0"
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
 

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -1,5 +1,5 @@
 module TestImages
-using FileIO, AxisArrays
+using FileIO, AxisArrays, OffsetArrays
 using Pkg.Artifacts
 using StringDistances
 using ColorTypes
@@ -90,6 +90,9 @@ function testimage(filename; download_only::Bool = false, ops...)
         # orientation is posterior-right-superior,
         # see http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm
         return AxisArray(img, (:P, :R, :S), (1, 1, 5))
+    elseif basename(imagefile) == "simple_3d_psf"
+        # zero-shift is in the middle
+        return OffsetArray(img, whatever_the_offset_is)
     end
     img
 end


### PR DESCRIPTION
Many frameworks take for granted that the middle of the PSF
is the "zero translation" spot, but this is neither general nor
necessary. It's better to encode the zero explicitly.