### PR TITLE
Fix the PSF image centering

### DIFF
--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -95,8 +95,8 @@ function testimage(filename; download_only::Bool = false, ops...)
         # orientation is posterior-right-superior,
         # see http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm
         return AxisArray(img::Array{Gray{N0f8},3}, (:P, :R, :S), (1, 1, 5))
-    elseif basename(imagefile) == "simple_3d_psf"
-        # zero frequency is at (0, 0, 0)
+    elseif basename(imagefile) == "simple_3d_psf.tif"
+        # kernel center is at (0, 0, 0)
         return OffsetArray(img::Array{Gray{N0f8},3}, (-33, -33, -33))
     end
     img

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
-using TestImages, FixedPointNumbers, Colors, AxisArrays
+using TestImages, FixedPointNumbers, Colors
+using AxisArrays: AxisArray, axisvalues
 using Test, ReferenceTests, Suppressor
 using ImageContrastAdjustment
 
@@ -18,6 +19,11 @@ img = testimage("mri-stack")
 @test isa(img, AxisArray)
 @test map(step, axisvalues(img)) == (1,1,5)
 @test_nowarn testimage("c")
+# Test that the PSF image is centered
+img = testimage("simple_3d_psf")
+map(axes(img)) do ax
+    @test abs(first(ax) + last(ax)) <= 1
+end
 
 # mismatch handling
 # Note: the behavior might change as `remotefiles` changes


### PR DESCRIPTION
Because of a mistake in the filename comparison, the OffsetArray
wrapper wasn't being applied.

Even though this changes the output type and behavior, this is clearly a bug,
so the fix should not be considered breaking.