### PR TITLE
upgrade to newer ImageIO and ColorVectorSpace version

### DIFF
--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -94,10 +94,10 @@ function testimage(filename; download_only::Bool = false, ops...)
     if basename(imagefile) == "mri-stack.tif"
         # orientation is posterior-right-superior,
         # see http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm
-        return AxisArray(img::Array{Gray{N0f8},3}, (:P, :R, :S), (1, 1, 5))
+        return AxisArray(convert(Array{Gray{N0f8},3}, img), (:P, :R, :S), (1, 1, 5))
     elseif basename(imagefile) == "simple_3d_psf.tif"
         # kernel center is at (0, 0, 0)
-        return OffsetArray(img::Array{Gray{N0f8},3}, (-33, -33, -33))
+        return OffsetArray(convert(Array{Gray{N0f8},3}, img), (-33, -33, -33))
     end
     img
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ err_str = @capture_err testimage("camereman")
     @test_reference "references/shepp_logan_CT_128.txt" adjust_histogram(phantom_ct, LinearStretching())
     @test_reference "references/shepp_logan_MRI_128.txt" phantom_mri
 
-    _norm(x) = sqrt(sum(abs2, x))
+    _norm(A) = sqrt(sum(c->mapreducec(abs2, +, 0, c), A))
     P = [ 0.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0;
           0.0  0.0  1.0  0.2  0.2  1.0  0.0  0.0;
           0.0  0.0  0.2  0.3  0.3  0.2  0.0  0.0;


### PR DESCRIPTION
64b0da5 fixes #112 

ImageIO v0.5 introduces TiffImages for tif image loading, which returns a custom array type:

```julia
julia> testimage("camera") |> summary
"512×512 TiffImages.DenseTaggedImage{ColorTypes.Gray{FixedPointNumbers.N0f8}, 2, UInt32, Matrix{ColorTypes.Gray{FixedPointNumbers.N0f8}}}"
```

which, unfortunately, breaks the type assertion.