### PR TITLE
[WIP] require ImageMagick as project dependency (and remove FileIO)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,14 @@ version = "1.5.0"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StringDistances = "88034a9c-02f8-509d-84a9-84ec65e18404"
 
 [compat]
 AxisArrays = "0.3, 0.4"
-ColorTypes = "0.8, 0.9, 0.10, 0.11"
-FileIO = "1"
+ImageMagick = "1"
 OffsetArrays = "1"
 StringDistances = "0.10"
 julia = "1.3"
@@ -22,11 +20,9 @@ julia = "1.3"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 FixedPointNumbers = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 ImageContrastAdjustment = "f332f351-ec65-5f6a-b3d1-319c6670881a"
-ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
-OMETIFF = "2d0ec36b-e807-5756-994b-45af29551fcf"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Colors", "FixedPointNumbers", "ImageMagick", "ImageContrastAdjustment", "OMETIFF", "ReferenceTests", "Suppressor", "Test"]
+test = ["Colors", "FixedPointNumbers", "ImageContrastAdjustment", "ReferenceTests", "Suppressor", "Test"]

--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -1,9 +1,9 @@
 module TestImages
-using FileIO, AxisArrays, OffsetArrays
+using AxisArrays, OffsetArrays
 using Pkg.Artifacts
 using StringDistances
-using ColorTypes
-using ColorTypes.FixedPointNumbers
+using ImageMagick
+using ImageMagick.ImageCore
 const artifacts_toml = abspath(joinpath(@__DIR__, "..", "Artifacts.toml"))
 
 export testimage
@@ -64,7 +64,7 @@ Load test image that partially matches `filename`, the first match is used if th
 than one.
 
 If `download_only=true`, the full filepath is returned.
-Any other keyword arguments `ops` will be passed to image IO backend through `FileIO.load`.
+Any other keyword arguments `ops` will be passed to image IO backend through `ImageMagick.load`.
 
 # Example
 
@@ -91,7 +91,7 @@ function testimage(filename; download_only::Bool = false, ops...)
 
     download_only && return imagefile
 
-    img = load(imagefile; ops...)
+    img = ImageMagick.load(imagefile; ops...)
     if basename(imagefile) == "mri-stack.tif"
         # orientation is posterior-right-superior,
         # see http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm


### PR DESCRIPTION
The reason we don't use `ImageIO` here is that ImageIO doesn't yet support gif format for `blobs.gif`.

```julia
julia> @time using TestImages
  1.841601 seconds (3.30 M allocations: 222.129 MiB, 2.06% gc time) # PR
  0.925069 seconds (1.38 M allocations: 93.332 MiB, 0.87% gc time) # master

julia> @time testimage("camera");
  0.500725 seconds (1.75 M allocations: 101.380 MiB, 4.84% gc time, 97.11% compilation time) # PR
  2.156676 seconds (6.17 M allocations: 364.787 MiB, 5.29% gc time, 12.69% compilation time) # master
```

My final vision is to also add this package into `Images.jl`, but I'm not very satisfied with the loading overhead here.

A perhaps "good" solution that I've not tried is to hardcode the direct IO backend that we're going to use for each file in `remotefiles`, so that we can get rid of the overhead of lazy-loading of `FileIO` and `ImageIO` and make the module more friendly to precompilation.