### PR TITLE
reduce CI workload

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
 
 jobs:
   test:
@@ -19,7 +17,12 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.3', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
+        include:
+          - os: windows-latest
+            julia-version: '1'
+          - os: macOS-latest
+            julia-version: '1'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
remove scheduled CI because otherwise Github Action will disable the
whole CI if the repo is not active for 60 days.

only test windows-latest and macos-latest for Julia 1.x release to
save our limited CI resources