### PR TITLE
Fix ci badge in `gh-pages`

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,8 @@
 				<h4>
 					A repository of standard test images for <a
 					href="https://github.com/JuliaImages/Images.jl">Images.jl</a></h4>
-				<a href="https://travis-ci.org/JuliaImages/TestImages.jl">
-					<img src="https://travis-ci.org/JuliaImages/TestImages.jl.png" class="center-block">
+				<a href="https://github.com/JuliaImages/TestImages.jl/actions">
+					<img src="https://github.com/JuliaImages/TestImages.jl/workflows/Unit%20test/badge.svg" class="center-block">
 				</a>
 				<h3>Installation</h3>
 				<p>On Linux and OSX, this should install automatically. If you find


### PR DESCRIPTION
Fix a badge in https://testimages.juliaimages.org/.

Btw, is there any plan to switch to Documenter.jl?
I thought it will be easy to maintain.