### PR TITLE
compress git history on gh-pages

### DIFF
--- a/docs/generate_imagelist.jl
+++ b/docs/generate_imagelist.jl
@@ -8,13 +8,6 @@ function generate_imagelist(root)
     sizes = size.(imgs)
     paths = ones(String,N)
 
-    # Save original images
-    mkpath(joinpath(root, "images"))
-    for i in 1:N
-        filename = filenames[i]
-        cp(TestImages.image_path(filename), joinpath(root, "images", filename), force=true)
-    end
-
     # Generate and save thumbnails
     mkpath(joinpath(root, "thumbnails"))
     HEIGHT = 200
@@ -73,12 +66,12 @@ function generate_imagelist(root)
 
     for i in 1:N
         filename = filenames[i]
-        path_orginal = joinpath("images", filename)
+        path_original = "https://raw.githubusercontent.com/JuliaImages/TestImages.jl/images/images/" * filename
         path_thumbnail = joinpath("thumbnails", basename(paths[i]))
         color = colors[i]
         size = sizes[i]
         # TODO: fill the `note` section referring to metadata.yml
-        script *= "| ![]($(path_thumbnail)) | [`$(filename)`]($(path_orginal)) | `$(color)` | `$(size)` |  |\n"
+        script *= "| ![]($(path_thumbnail)) | [`$(filename)`]($(path_original)) | `$(color)` | `$(size)` |  |\n"
     end
 
     write(joinpath(root, "imagelist.md"), script)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -21,5 +21,8 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/JuliaImages/TestImages.jl"
+    repo="github.com/JuliaImages/TestImages.jl",
+    # A lot of thumbnails are generated, so compressing history in `gh-pages` avoids infinite
+    # storage increasement.
+    forcepush=true,
 )


### PR DESCRIPTION
Just future-proof to not become https://github.com/JuliaImages/juliaimages.github.io/issues/211

- `images/` folder is removed, instead, I use the raw link to the `images/` folder in the `images` branch
- deploy docs with force-push so that we don't increase 4.8M thumbnails data for each of our new commits.