### PR TITLE
Add generation of the note section in the image list

### DIFF
--- a/docs/generate_imagelist.jl
+++ b/docs/generate_imagelist.jl
@@ -83,10 +83,7 @@ function extract_name(metadata, filename)
 
     name = splitext(filename)[1]
     j = findfirst(data -> data["name"]==name, metadata)
-    if isnothing(j)
-        # If full name isn't available, a filename with link to its original image will be returned
-        return link
-    else
+    if !isnothing(j)
         # If full name is available, full name in bold and its link will be returned
         data = metadata[j]
         if "fullname" in keys(data)
@@ -94,6 +91,8 @@ function extract_name(metadata, filename)
             return "**$(fullname)**, " * link
         end
     end
+    # If full name isn't available, a filename with link to its original image will be returned
+    return link
 end
 
 function extract_note(metadata, filename)

--- a/docs/generate_imagelist.jl
+++ b/docs/generate_imagelist.jl
@@ -15,7 +15,7 @@ function generate_imagelist(root)
 
         if length(sizes[i]) == 2
             # Normal image
-            width = round(Int, HEIGHT / /(sizes[i]...))
+            width = round(Int, HEIGHT / sizes[i][1] * sizes[i][2])
             thumbnail = imresize(imgs[i], HEIGHT, width)
             path = joinpath(root, "thumbnails", names[i]*".png")
             paths[i] = path
@@ -23,8 +23,7 @@ function generate_imagelist(root)
 
         elseif length(sizes[i]) == 3
             # 3-dimensional image, will be converted animated gif
-            width = round(Int, HEIGHT / /(sizes[i][1],sizes[i][2]))
-
+            width = round(Int, HEIGHT / sizes[i][1] * sizes[i][2])
             img = collect(imgs[i])
             thumbnail = Array{eltype(img),3}(undef,HEIGHT,width,sizes[i][3])
             for j in 1:sizes[i][3]
@@ -37,10 +36,9 @@ function generate_imagelist(root)
 
         elseif length(sizes[i]) == 4
             # multi-channel image, will be converted animated gif
-            width = round(Int, HEIGHT / /(sizes[i][1],sizes[i][2]))
+            width = round(Int, HEIGHT / sizes[i][1] * sizes[i][2])
             n_frames = sizes[i][3] * sizes[i][4]
             img = reshape(permutedims(collect(imgs[i]),(1,2,4,3)),sizes[i][1],sizes[i][2],n_frames)
-            
             thumbnail = Array{eltype(img),3}(undef,HEIGHT,width,n_frames)
             for j in 1:n_frames
                 thumbnail[:,:,j] = imresize(img[:,:,j], HEIGHT, width)
@@ -52,35 +50,9 @@ function generate_imagelist(root)
         end
     end
 
-    # Refer to the metadata
+    # Load the metadata
     path_toml = TestImages.image_path("metadata.toml")
     metadata = Dict{String,String}.(TOML.parsefile(path_toml)["images"])
-
-    fullnames = ones(String, N)
-    notes = [String[] for i in 1:N]
-
-    for i in 1:N
-        name = splitext(filenames[i])[1]
-        j = findfirst(data -> data["name"]==name, metadata)
-        if !isnothing(j)
-            data = metadata[j]
-            if "fullname" in keys(data)
-                fullnames[i] = data["fullname"]
-            end
-            if "url" in keys(data)
-                url = data["url"]
-                push!(notes[i], "[origin]($(url))")
-            end
-            if "author" in keys(data)
-                author = data["author"]
-                push!(notes[i], "by $(author)")
-            end
-            if "lisence" in keys(data)
-                lisence = data["lisence"]
-                push!(notes[i], "$(lisence)")
-            end
-        end
-    end
 
     # Generate markdown, including a table of images
     script = """
@@ -92,18 +64,58 @@ function generate_imagelist(root)
 
     for i in 1:N
         filename = filenames[i]
-        fullname = fullnames[i]
-        path_original = "https://raw.githubusercontent.com/JuliaImages/TestImages.jl/images/images/" * filename
         path_thumbnail = joinpath("thumbnails", basename(paths[i]))
         color = colors[i]
         size = sizes[i]
-        note = join(notes[i], ", ")
-        name = "[`$(filename)`]($(path_original))"
-        if fullname != ""
-            name = "**$(fullname)**, " * name
-        end
+        name = extract_name(metadata, filename)
+        note = extract_note(metadata, filename)
         script *= "| ![]($(path_thumbnail)) | $(name) | `$(color)` | `$(size)` | $(note) |\n"
     end
 
     write(joinpath(root, "imagelist.md"), script)
+end
+
+function extract_name(metadata, filename)
+    # Extract name section in the table
+
+    path_original = "https://raw.githubusercontent.com/JuliaImages/TestImages.jl/images/images/" * filename
+    link = "[`$(filename)`]($(path_original))"
+
+    name = splitext(filename)[1]
+    j = findfirst(data -> data["name"]==name, metadata)
+    if isnothing(j)
+        # If full name isn't available, a filename with link to its original image will be returned
+        return link
+    else
+        # If full name is available, full name in bold and its link will be returned
+        data = metadata[j]
+        if "fullname" in keys(data)
+            fullname = data["fullname"]
+            return "**$(fullname)**, " * link
+        end
+    end
+end
+
+function extract_note(metadata, filename)
+    # Extract note section in the table
+
+    name = splitext(filename)[1]
+    j = findfirst(data -> data["name"]==name, metadata)
+    note = String[]
+    if !isnothing(j)
+        data = metadata[j]
+        if "url" in keys(data)
+            url = data["url"]
+            push!(note, "[origin]($(url))")
+        end
+        if "author" in keys(data)
+            author = data["author"]
+            push!(note, "by $(author)")
+        end
+        if "lisence" in keys(data)
+            lisence = data["lisence"]
+            push!(note, "$(lisence)")
+        end
+    end
+    return join(note, ", ")
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, TestImages, Images, OMETIFF
+using Documenter, TestImages, Images, OMETIFF, TOML
 
 include("generate_imagelist.jl")
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -8,7 +8,7 @@ The following steps should be followed to add an image/imageset to the repositor
 1. Check the images for copyright or license issues before adding images.
 1. Do `git checkout images` in your local repository folder. `Pkg.dir("TestImages")` gives the location of the repo.
 1. Add the image locally to the `images/` folder on your machine.
-1. If you have metadata, a more common name, a url for the source or an author, you can add that to the `metadata.yml`.
+1. If you have metadata, a more common name, a url for the source or an author, you can add them to the `images/metadata.toml`.
 1. Do `git add --all` to stage the changes for a commit.
 1. `git commit -m "Adds <filename> to the repository from link <link>"`
 1. `git push <fork> images`


### PR DESCRIPTION
Here's a screenshot.

![testimages_documenter3](https://user-images.githubusercontent.com/7488140/129217213-1594cc56-e7fb-4d0c-9d32-466d348e218a.gif)

We can merge this PR after next artifacts which includes `images/metadata.toml` will be released.