### PR TITLE
make the Lena deprecation warning an actual deprecation

### DIFF
--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -92,7 +92,7 @@ function testimage(filename; download_only::Bool = false, ops...)
     imagefile = image_path(full_imagename(filename))
 
     if startswith(basename(imagefile), "lena_")
-        @warn "Usage of \"lena\" is not recommended, and the image may be removed in a later release. See https://womenlovetech.com/losing-lena-why-we-need-to-remove-one-image-and-end-techs-original-sin/ for more information." maxlog=1
+        Base.depwarn("Usage of \"lena\" is not recommended, and the image may be removed in a later release. See https://womenlovetech.com/losing-lena-why-we-need-to-remove-one-image-and-end-techs-original-sin/ for more information.",  nothing)
     end
 
     download_only && return imagefile


### PR DESCRIPTION
Otherwise it shows up in inconvenient places like:

![image](https://user-images.githubusercontent.com/1282691/147506862-e051caae-e67e-4832-ada8-fb08972f2ed2.png)

This will still be shown for peope who want to see deprecation warnings and run with `--depwarn=yes`.
