### PR TITLE
add undocumented nowarn keyword for `testimage`

### DIFF
--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -88,10 +88,10 @@ https://testimages.juliaimages.org/
 
 $(reduce((x, y)->join([x, "\n - \`\"", splitext(y)[1], "\"\`"]), sort(remotefiles); init=""))
 """
-function testimage(filename; download_only::Bool = false, ops...)
+function testimage(filename; download_only::Bool = false, nowarn=false, ops...)
     imagefile = image_path(full_imagename(filename))
 
-    if startswith(basename(imagefile), "lena_")
+    if nowarn || startswith(basename(imagefile), "lena_")
         @warn "Usage of \"lena\" is not recommended, and the image may be removed in a later release. See https://womenlovetech.com/losing-lena-why-we-need-to-remove-one-image-and-end-techs-original-sin/ for more information." maxlog=1
     end
 


### PR DESCRIPTION
An alternative to #143. @KristofferC does this look good to you?

I deliberately don't document it here because I'm not going to recommend using it. But if anything, users can easily find and understand what this keyword does by reading the source codes.

closes #143