### PR TITLE
Remove forced conversion of mri stack

### DIFF
--- a/src/TestImages.jl
+++ b/src/TestImages.jl
@@ -130,7 +130,7 @@ function testimage(filename; download_only::Bool = false, nowarn=false, ops...)
     if basename(imagefile) == "mri-stack.tif"
         # orientation is posterior-right-superior,
         # see http://www.grahamwideman.com/gw/brain/orientation/orientterms.htm
-        return AxisArray(convert(Array{Gray{N0f8},3}, img), (:P, :R, :S), (1, 1, 5))
+        return AxisArray(img, (:P, :R, :S), (1, 1, 5))
     elseif basename(imagefile) == "simple_3d_psf.tif"
         # kernel center is at (0, 0, 0)
         return OffsetArray(convert(Array{Gray{N0f8},3}, img), (-33, -33, -33))


### PR DESCRIPTION
As pointed out in https://github.com/ElisabethRoesch/Perspective_Julia_for_Biologists/issues/5, forced conversion of the MRI stack specifically means that users might be surprised that `testimage("mri"; mmap = true)` doesn't actually load the image lazily while it should work well for other TIFFs in the dataset.

This PR removes the forced conversion and it appears to pass all relevant tests @johnnychen94 @timholy 